### PR TITLE
Fix Failure on Rubinius

### DIFF
--- a/ext/glfw3/glfw3.c
+++ b/ext/glfw3/glfw3.c
@@ -516,9 +516,9 @@ static VALUE rb_monitor_set_gamma_ramp(VALUE self, VALUE ramp_hash)
   ramp.blue = &ramp_buffer[ramp_len * 2];
 
   for (ramp_index = 0; ramp_index < ramp_len; ++ramp_index) {
-    ramp.red[ramp_index] = rb_num2ushort(rb_ary_entry(rb_red, ramp_index));
-    ramp.green[ramp_index] = rb_num2ushort(rb_ary_entry(rb_green, ramp_index));
-    ramp.blue[ramp_index] = rb_num2ushort(rb_ary_entry(rb_blue, ramp_index));
+    ramp.red[ramp_index] = rb_num2uint(rb_ary_entry(rb_red, ramp_index));
+    ramp.green[ramp_index] = rb_num2uint(rb_ary_entry(rb_green, ramp_index));
+    ramp.blue[ramp_index] = rb_num2uint(rb_ary_entry(rb_blue, ramp_index));
   }
 
   ramp.size = ramp_len;


### PR DESCRIPTION
Since Rubinius does not have rb_num2ushort, I replaced it with rb_num2uint.
