### PR TITLE
fixing GL namespace in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,25 +36,23 @@ After that, write a quick script to toy with it. For example:
     window = Glfw::Window.new(800, 600, "Foobar")
 
     # Set some callbacks
-    window.set_key_callback {
-      |window, key, code, action, mods|
+    window.set_key_callback do |window, key, code, action, mods|
       window.should_close = true if key == Glfw::KEY_ESCAPE
-    }
+    end
 
-    window.set_close_callback {
-      |window|
+    window.set_close_callback do |window|
       window.should_close = true
-    }
+    end
 
     # Make the window's context current
     window.make_context_current
-    loop {
+    loop do
       # And do stuff
       Glfw.wait_events
-      Gl.glClear(Gl::GL_COLOR_BUFFER_BIT | Gl::GL_DEPTH_BUFFER_BIT)
+      GL.glClear(GL::GL_COLOR_BUFFER_BIT | GL::GL_DEPTH_BUFFER_BIT)
       window.swap_buffers
       break if window.should_close?
-    }
+    end
 
     # Explicitly destroy the window when done with it.
     window.destroy


### PR DESCRIPTION
@nilium

Fixing the namespace of `Gl` to `GL` which the `opengl-core` gem includes. 

I was getting this error:

```
lib/test.rb:25:in `block in <main>': uninitialized constant Gl (NameError)
    from lib/test.rb:22:in `loop'
    from lib/test.rb:22:in `<main>'
```

Also updated the blocks to do/end syntax since they are multiline. Thanks!
